### PR TITLE
Update dependencies and config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,5 +12,7 @@
   "parserOptions": {
     "sourceType": "module"
   },
-  "rules": {}
+  "rules": {
+    "@typescript-eslint/strict-boolean-expressions": "off"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,17 +15,17 @@
   "dependencies": {
     "axios": "^1.7.0",
     "dotenv": "^16.4.5",
-    "model-context-protocol": "^0.4.2",
-    "vercel-ai": "^1.1.0",
+    "model-context-protocol": "^1.0.2",
+    "ai": "^4.3.19",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "typescript": "^5.5.0",
     "@types/node": "^20.8.0",
     "ts-node": "^10.9.1",
-    "eslint": "^8.57.0",
-    "@typescript-eslint/eslint-plugin": "^6.9.0",
-    "@typescript-eslint/parser": "^6.9.0",
+    "eslint": "^9.31.0",
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@typescript-eslint/parser": "^7.2.0",
     "prettier": "^3.3.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1"

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { serve } from "vercel-ai/sdk";
+import { serve } from "ai/server";
 import { cryptoScannerTool } from "./agents/cryptoScanner";
 
 if (!process.env.TAAPI_KEY || !process.env.CMC_KEY) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,10 @@
     "target": "ES2020",
     "moduleResolution": "node",
     "outDir": "dist",
+    "skipLibCheck": true,
+    "incremental": true,
     "esModuleInterop": true,
-    "strict": true,
-    "skipLibCheck": true
+    "strict": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- update package versions to 2025-07-20 stable releases
- use `ai/server` import from the renamed Vercel AI SDK
- disable strict boolean expressions in ESLint
- enable incremental TS builds

## Testing
- `pnpm add -g pnpm@10.13.1` *(fails: Unable to find the global bin directory)*
- `pnpm install` *(fails: GET https://registry.npmjs.org/typescript: Forbidden - 403)*
- `pnpm run lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c7d088b648327bf64693fbed8d76c